### PR TITLE
Add support for relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,11 @@ npm-link-local /first/module /second/module
 npm-link-local relative/path
 ```
 
+You can also use --relative to make a symlink with a relative path
+
+```
+npm-link-local ~/Projects/test --relative
+```
+
 # TODO
 Tests

--- a/cli.js
+++ b/cli.js
@@ -3,4 +3,4 @@
 
 var npmLinkLocal = require('./');
 
-npmLinkLocal(process.argv.slice(2));
+npmLinkLocal(require('optimist').argv)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var npmInstall = function(modulePath) {
 	});
 };
 
-var linkToNodeModules = function(modulePath) {
+var linkToNodeModules = function(modulePath, relative) {
 	var target = path.resolve(process.cwd(), modulePath);
 
 	var moduleName = modulePath.split('/');
@@ -36,20 +36,33 @@ var linkToNodeModules = function(modulePath) {
 			//link didn't exists
 		}
 	}
-
+	if (relative) {
+		target = relativizePath(target, link);
+	}
 	console.log(link, '->', target);
+
 
 	return fs.symlinkSync(target, link, 'junction');
 };
 
-var npmLinkLocal = function(modulesPath) {
-	if (typeof modulesPath=== 'string') {
-		modulesPath= [modulesPath];
-	}
+function relativizePath(target, link) {
+	var separator = /[\\/]/
+	var targetArr = target.split(separator),
+	    linkArr = link.split(separator),
+	    common = 0;
+	while (targetArr[common] === linkArr[common]) ++common
+	if (common === 0) return target;
+	targetArr = targetArr.slice(common)
+	linkArr = linkArr.slice(common)
+	var prefix = Array(linkArr.length).join('../') || './'
+	return prefix + targetArr.join('/')
+}
 
+var npmLinkLocal = function(opts) {
+    var modulesPath = opts._;
 	for (var i = 0, l = modulesPath.length; i < l; i++) {
 		npmInstall(modulesPath[i]);
-		linkToNodeModules(modulesPath[i]);
+		linkToNodeModules(modulesPath[i], opts.relative);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -4,24 +4,27 @@
   "description": "like npm link, but just local (npm install and symlink to node-modules)",
   "main": "index.js",
   "bin": {
-	"npm-link-local": "cli.js"
+    "npm-link-local": "cli.js"
   },
   "scripts": {
-	"test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
-	"type": "git",
-	"url": "git+https://github.com/Anmo/npm-link-local.git"
+    "type": "git",
+    "url": "git+https://github.com/Anmo/npm-link-local.git"
   },
   "keywords": [
-	"npm",
-	"link",
-	"local"
+    "npm",
+    "link",
+    "local"
   ],
   "author": "Anmo",
   "license": "MIT",
   "bugs": {
-	"url": "https://github.com/Anmo/npm-link-local/issues"
+    "url": "https://github.com/Anmo/npm-link-local/issues"
   },
-  "homepage": "https://github.com/Anmo/npm-link-local#readme"
+  "homepage": "https://github.com/Anmo/npm-link-local#readme",
+  "dependencies": {
+    "optimist": "^0.6.1"
+  }
 }


### PR DESCRIPTION
This is convenient for mounted file systems such as Docker, or for moving entire directories full of projects around without affecting symlinks