### PR TITLE
Use rimraf for clean recursive file removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-link-local",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "like npm link, but just local (npm install and symlink to node-modules)",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/Anmo/npm-link-local#readme",
   "dependencies": {
-    "optimist": "^0.6.1"
+    "optimist": "^0.6.1",
+    "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
The current implementation gets confused sometimes if there are links from node_modules/.bin/file to a module. It would delete the module first, then when it gets to the symlink in `.bin`, `fs.statSync` will throw because the link points to a non-existent file, and the recursive deletion will fail.